### PR TITLE
twitterログインをローカル環境から本番環境に変更

### DIFF
--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -118,7 +118,7 @@ Rails.application.config.sorcery.configure do |config|
   #
   config.twitter.key = Rails.application.credentials.dig(:twitter, :key)
   config.twitter.secret = Rails.application.credentials.dig(:twitter, :secret_key)
-  # config.twitter.callback_url = 'http://localhost:3000/oauth/callback?provider=twitter'
+  config.twitter.callback_url = 'https://hoshime.herokuapp.com/oauth/callback?provider=twitter'
   config.twitter.user_info_mapping = { email: 'screen_name', name: 'name' }
   #
   # config.facebook.key = ""


### PR DESCRIPTION
## 概要

9123724a9a0321074fd01fa0dc3081a89076c349
twitterログインをローカル環境から本番環境の仕様に変更しました。

## 確認方法
デプロイ後にhttps://hoshime.herokuapp.com/ にアクセスしてtwitterログインしてください。


## 影響範囲
twitterログイン周りのみ。
（sorceryファイルとtwitter Developer周りいじってます。）

## チェックリスト
- [ ] Lint のチェックをパスした

## コメント

デプロイしたら確認お願いします。
