### PR TITLE
欲しいもの登録の値段入力フォームで現在値を表示

### DIFF
--- a/app/javascript/library/jquery.range.css
+++ b/app/javascript/library/jquery.range.css
@@ -24,9 +24,10 @@
 }
 .slider-container .back-bar .pointer-label {
   position: absolute;
-  top: -17px;
-  font-size: 8px;
-  background: white;
+  top: -30px;
+  left: 40px;
+  font-size: 15px;
+  background: rgba(255, 251, 235, var(--tw-bg-opacity));
   white-space: nowrap;
   line-height: 1;
 }

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -67,11 +67,11 @@ $('#item_price').jRange({
   from: 0,
   to: 100000,
   step: 1000,
-  format: '%s 万円',
+  format: '%s円',
   scale: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, "10万円"],
   width: '100%',
   theme: "theme-blue",
-  showLabels: false,
+  showLabels: true,
   onstatechange: function(){
     $("#item_price").trigger('change');
   }

--- a/app/views/three_items/new.html.erb
+++ b/app/views/three_items/new.html.erb
@@ -86,11 +86,11 @@
     from: 0,
     to: 100000,
     step: 1000,
-    format: '%s 万円',
+    format: '%s円',
     scale: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, "10万円"],
     width: '100%',
     theme: "theme-blue",
-    showLabels: false,
+    showLabels: true,
     onstatechange: function(){
       $("#item_price").trigger('change');
     }


### PR DESCRIPTION
## 概要
1d823d524fae7fd30cda3f971e841153228ab4f5 欲しいもの3つ登録ページの値段の入力フォームで現在値を表示するようにしました。
6853a4cdc8de735b3b8c62f3e195c2668f835c36 同様に1つ登録する場合でも値段の現在値を表示するようにしました。

改修前
[![Image from Gyazo](https://i.gyazo.com/6a9e9611ca36c34202ba1b6a4da9ed5e.gif)](https://gyazo.com/6a9e9611ca36c34202ba1b6a4da9ed5e)

改修後
[![Image from Gyazo](https://i.gyazo.com/2bcfea65b19d6d20449127c80051ee5e.gif)](https://gyazo.com/2bcfea65b19d6d20449127c80051ee5e)

## 確認方法
1. 欲しいもの3つ登録ページ`/three_items/new`にアクセスして値段のフォームの上部に現在値が表示されることを確認してください。
2. 同様に欲しいもの1つ登録ページ`items/new`にアクセスして値段の現在値が表示されることを確認してください。

## 影響範囲
特になし

## チェックリスト
- [ ] Lint のチェックをパスした

## コメント
ユーザーから値段の現在値を見れた方が良いという声を頂いたので修正しました。